### PR TITLE
fix: only count Hackatime time after BEGIN_DATE

### DIFF
--- a/src/hackatime.ts
+++ b/src/hackatime.ts
@@ -19,8 +19,13 @@ export class Hackatime {
         this.key = key;
     }
 
-    async getProjectsFor(username: string): Promise<HackatimeProject[]> {
-        const res = await fetch(`https://hackatime.hackclub.com/api/v1/users/${username}/projects/details`, {
+    async getProjectsFor(username: string, startDate?: Date): Promise<HackatimeProject[]> {
+        const url = new URL(`https://hackatime.hackclub.com/api/v1/users/${username}/projects/details`);
+        if (startDate) {
+            url.searchParams.set("start_date", startDate.toISOString());
+        }
+
+        const res = await fetch(url, {
             method: "GET",
             headers: new Headers({
                 "User-Agent": "iplace/1.0.0",

--- a/src/pages/admin/submissions.astro
+++ b/src/pages/admin/submissions.astro
@@ -2,7 +2,7 @@
 import AdminLayout from "../../components/AdminLayout.astro";
 import prisma from "../../lib/prisma";
 import { Hackatime } from "../../hackatime";
-import { SECONDS_PER_TILE } from "../../config";
+import { SECONDS_PER_TILE, BEGIN_DATE } from "../../config";
 import { getSlackUsernames } from "../../lib/slack";
 import type { SubmissionStatus } from "../../prisma/generated/client";
 
@@ -21,7 +21,7 @@ const hackatimeTimes = new Map<number, number>(); // submission id -> total seco
 for (const sub of submissions) {
   if (sub.status !== "PENDING") continue;
   try {
-    const projects = await hackatime.getProjectsFor(sub.owner.slackId);
+    const projects = await hackatime.getProjectsFor(sub.owner.slackId, BEGIN_DATE);
     const projectNames = sub.hackatimeProjectNames.split(",").map(n => n.trim());
     let total = 0;
     for (const name of projectNames) {

--- a/src/pages/api/admin/submissions/[id]/approve.ts
+++ b/src/pages/api/admin/submissions/[id]/approve.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getAdminFromRequest, notAdminResponse } from "../../../../../lib/admin";
 import { validateRequestBody, jsonError, jsonResponse } from "../../../../../lib/api-util";
 import prisma from "../../../../../lib/prisma";
-import { SECONDS_PER_TILE } from "../../../../../config";
+import { SECONDS_PER_TILE, BEGIN_DATE } from "../../../../../config";
 import { Hackatime } from "../../../../../hackatime";
 import { syncSubmissionToAirtable } from "../../../../../lib/airtable";
 import { sendSlackDM } from "../../../../../lib/slack";
@@ -40,7 +40,7 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   // Calculate approved time from Hackatime
   const projectNamesList = submission.hackatimeProjectNames.split(",").map(n => n.trim());
-  const allProjects = await hackatime.getProjectsFor(submission.owner.slackId);
+  const allProjects = await hackatime.getProjectsFor(submission.owner.slackId, BEGIN_DATE);
 
   let approvedTime = 0;
   for (const projectName of projectNamesList) {

--- a/src/pages/api/hackatime-projects.ts
+++ b/src/pages/api/hackatime-projects.ts
@@ -26,7 +26,7 @@ export const GET: APIRoute = async ({ request }) => {
     const url = new URL(request.url);
     const excludeFrameId = parseInt(url.searchParams.get("excludeFrameId") ?? "", 10) || null;
 
-    const allProjects = await hackatime.getProjectsFor(user.slackId);
+    const allProjects = await hackatime.getProjectsFor(user.slackId, BEGIN_DATE);
 
     const userFrames = await prisma.frame.findMany({
         where: { ownerId: user.id },

--- a/src/pages/api/submissions/create.ts
+++ b/src/pages/api/submissions/create.ts
@@ -50,8 +50,7 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   // Verify Hackatime projects exist and have sufficient time
-  const allProjects = await hackatime.getProjectsFor(user.slackId);
-  const beginDate = new Date(BEGIN_DATE);
+  const allProjects = await hackatime.getProjectsFor(user.slackId, BEGIN_DATE);
 
   for (const projectName of hackatimeProjectNames) {
     const project = allProjects.find(p => p.name === projectName);
@@ -61,7 +60,7 @@ export const POST: APIRoute = async ({ request }) => {
     if (project.total_seconds < 60) {
       return jsonError(400, `Hackatime project "${projectName}" has less than 1 minute of time`);
     }
-    if (new Date(project.last_heartbeat) < beginDate) {
+    if (new Date(project.last_heartbeat) < BEGIN_DATE) {
       return jsonError(400, `Hackatime project "${projectName}" has no activity after the program start date`);
     }
   }


### PR DESCRIPTION
## Summary
- Pass `start_date=BEGIN_DATE` to the Hackatime `/projects/details` API so `total_seconds` only reflects heartbeats after the program start date
- Previously, projects with pre-existing activity would get inflated tile counts from time tracked before BEGIN_DATE
- Updated all 5 call sites: project listing, submission creation, approval, and admin review page

## Test plan
- [ ] Verify that a project with time before and after BEGIN_DATE only shows post-BEGIN_DATE seconds
- [ ] Verify submission creation still validates projects correctly
- [ ] Verify admin approval calculates correct tile counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)